### PR TITLE
Modified Skillable-tms-OpenAPI.yaml

### DIFF
--- a/Skillable-tms-OpenAPI.yaml
+++ b/Skillable-tms-OpenAPI.yaml
@@ -320,6 +320,262 @@ paths:
           explode: true
           schema:
             type: string
+          deprecated: true
+        - name: countryCode
+          in: query
+          description: |
+            The 2-character code for the user's country.
+
+            **Allowed values**  
+
+              AF	Afghanistan  
+              AX	Åland Islands  
+              AL	Albania  
+              DZ	Algeria  
+              AS	American Samoa  
+              AD	Andorra  
+              AO	Angola  
+              AI	Anguilla  
+              AG	Antigua and Barbuda  
+              AR	Argentina  
+              AM	Armenia  
+              AW	Aruba  
+              AU	Australia  
+              AT	Austria  
+              AZ	Azerbaijan  
+              BS	Bahamas  
+              BH	Bahrain  
+              BD	Bangladesh  
+              BB	Barbados  
+              BY	Belarus  
+              BE	Belgium  
+              BZ	Belize  
+              BJ	Benin  
+              BM	Bermuda  
+              BT	Bhutan  
+              BO	Bolivia  
+              BQ	Bonaire, Sint Eustatius and Saba  
+              BA	Bosnia and Herzegovina  
+              BW	Botswana  
+              BR	Brazil  
+              IO	British Indian Ocean Territory  
+              VG	British Virgin Islands  
+              BN	Brunei  
+              BG	Bulgaria  
+              BF	Burkina Faso  
+              BI	Burundi  
+              CV	Cabo Verde  
+              KH	Cambodia  
+              CM	Cameroon  
+              CA	Canada  
+              KY	Cayman Islands  
+              CF	Central African Republic  
+              TD	Chad  
+              CL	Chile  
+              CN	China  
+              CX	Christmas Island  
+              CC	Cocos (Keeling) Islands  
+              CO	Colombia  
+              KM	Comoros  
+              CG	Congo  
+              CD	Congo (DRC)  
+              CK	Cook Islands  
+              CR	Costa Rica  
+              CI	Côte d’Ivoire  
+              HR	Croatia  
+              CU	Cuba  
+              CW	Curaçao  
+              CY	Cyprus  
+              CZ	Czech Republic  
+              DK	Denmark  
+              DJ	Djibouti  
+              DM	Dominica  
+              DO	Dominican Republic  
+              EC	Ecuador  
+              EG	Egypt  
+              SV	El Salvador  
+              GQ	Equatorial Guinea  
+              ER	Eritrea  
+              EE	Estonia  
+              ET	Ethiopia  
+              FK	Falkland Islands  
+              FO	Faroe Islands  
+              FJ	Fiji  
+              FI	Finland  
+              FR	France  
+              GF	French Guiana  
+              PF	French Polynesia  
+              GA	Gabon  
+              GM	Gambia  
+              GE	Georgia  
+              DE	Germany  
+              GH	Ghana  
+              GI	Gibraltar  
+              GR	Greece  
+              GL	Greenland  
+              GD	Grenada  
+              GP	Guadeloupe  
+              GU	Guam  
+              GT	Guatemala  
+              GG	Guernsey  
+              GN	Guinea  
+              GW	Guinea-Bissau  
+              GY	Guyana  
+              HT	Haiti  
+              HN	Honduras  
+              HK	Hong Kong SAR  
+              HU	Hungary  
+              IS	Iceland  
+              IN	India  
+              ID	Indonesia  
+              IR	Iran  
+              IQ	Iraq  
+              IE	Ireland  
+              IM	Isle of Man  
+              IL	Israel  
+              IT	Italy  
+              JM	Jamaica  
+              JP	Japan  
+              JE	Jersey  
+              JO	Jordan  
+              KZ	Kazakhstan  
+              KE	Kenya  
+              KI	Kiribati  
+              KR	Korea  
+              XK	Kosovo  
+              KW	Kuwait  
+              KG	Kyrgyzstan  
+              LA	Laos  
+              LV	Latvia  
+              LB	Lebanon  
+              LS	Lesotho  
+              LR	Liberia  
+              LY	Libya  
+              LI	Liechtenstein  
+              LT	Lithuania  
+              LU	Luxembourg  
+              MO	Macao SAR  
+              MK	Macedonia, FYRO  
+              MG	Madagascar  
+              MW	Malawi  
+              MY	Malaysia  
+              MV	Maldives  
+              ML	Mali  
+              MT	Malta  
+              MH	Marshall Islands  
+              MQ	Martinique  
+              MR	Mauritania  
+              MU	Mauritius  
+              YT	Mayotte  
+              MX	Mexico  
+              FM	Micronesia  
+              MD	Moldova  
+              MC	Monaco  
+              MN	Mongolia  
+              ME	Montenegro  
+              MS	Montserrat  
+              MA	Morocco  
+              MZ	Mozambique  
+              MM	Myanmar  
+              NA	Namibia  
+              NR	Nauru  
+              NP	Nepal  
+              NL	Netherlands  
+              NC	New Caledonia  
+              NZ	New Zealand  
+              NI	Nicaragua  
+              NE	Niger  
+              NG	Nigeria  
+              NU	Niue  
+              NF	Norfolk Island  
+              KP	North Korea  
+              MP	Northern Mariana Islands  
+              NO	Norway  
+              OM	Oman  
+              PK	Pakistan  
+              PW	Palau  
+              PS	Palestinian Authority  
+              PA	Panama  
+              PG	Papua New Guinea  
+              PY	Paraguay  
+              PE	Peru  
+              PH	Philippines  
+              PN	Pitcairn Islands  
+              PL	Poland  
+              PT	Portugal  
+              PR	Puerto Rico  
+              QA	Qatar  
+              RE	Réunion  
+              RO	Romania  
+              RU	Russia  
+              RW	Rwanda  
+              BL	Saint Barthélemy  
+              KN	Saint Kitts and Nevis  
+              LC	Saint Lucia  
+              MF	Saint Martin  
+              PM	Saint Pierre and Miquelon  
+              VC	Saint Vincent and the Grenadines  
+              WS	Samoa  
+              SM	San Marino  
+              ST	São Tomé and Príncipe  
+              SA	Saudi Arabia  
+              SN	Senegal  
+              RS	Serbia  
+              SC	Seychelles  
+              SL	Sierra Leone  
+              SG	Singapore  
+              SX	Sint Maarten  
+              SK	Slovakia  
+              SI	Slovenia  
+              SB	Solomon Islands  
+              SO	Somalia  
+              ZA	South Africa  
+              SS	South Sudan  
+              ES	Spain  
+              LK	Sri Lanka  
+              SH	St Helena, Ascension, Tristan da Cunha  
+              SD	Sudan  
+              SR	Suriname  
+              SJ	Svalbard and Jan Mayen  
+              SZ	Swaziland  
+              SE	Sweden  
+              CH	Switzerland  
+              SY	Syria  
+              TW	Taiwan  
+              TJ	Tajikistan  
+              TZ	Tanzania  
+              TH	Thailand  
+              TL	Timor-Leste  
+              TG	Togo  
+              TK	Tokelau  
+              TO	Tonga  
+              TT	Trinidad and Tobago  
+              TN	Tunisia  
+              TR	Turkey  
+              TM	Turkmenistan  
+              TC	Turks and Caicos Islands  
+              TV	Tuvalu  
+              UM	U.S. Outlying Islands  
+              VI	U.S. Virgin Islands  
+              UG	Uganda  
+              UA	Ukraine  
+              AE	United Arab Emirates  
+              GB	United Kingdom  
+              US	United States  
+              UY	Uruguay  
+              UZ	Uzbekistan  
+              VU	Vanuatu  
+              VE	Venezuela  
+              VN	Vietnam  
+              WF	Wallis and Futuna  
+              YE	Yemen  
+              ZM	Zambia  
+              ZW	Zimbabwe
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
         - name: zip
           in: query
           description: The user's zip/postal code.
@@ -714,6 +970,262 @@ paths:
         - name: country
           in: query
           description: The user's country.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          deprecated: true
+        - name: countryCode
+          in: query
+          description: |
+            The 2-character code for the user's country.
+
+            **Allowed values**  
+
+              AF	Afghanistan  
+              AX	Åland Islands  
+              AL	Albania  
+              DZ	Algeria  
+              AS	American Samoa  
+              AD	Andorra  
+              AO	Angola  
+              AI	Anguilla  
+              AG	Antigua and Barbuda  
+              AR	Argentina  
+              AM	Armenia  
+              AW	Aruba  
+              AU	Australia  
+              AT	Austria  
+              AZ	Azerbaijan  
+              BS	Bahamas  
+              BH	Bahrain  
+              BD	Bangladesh  
+              BB	Barbados  
+              BY	Belarus  
+              BE	Belgium  
+              BZ	Belize  
+              BJ	Benin  
+              BM	Bermuda  
+              BT	Bhutan  
+              BO	Bolivia  
+              BQ	Bonaire, Sint Eustatius and Saba  
+              BA	Bosnia and Herzegovina  
+              BW	Botswana  
+              BR	Brazil  
+              IO	British Indian Ocean Territory  
+              VG	British Virgin Islands  
+              BN	Brunei  
+              BG	Bulgaria  
+              BF	Burkina Faso  
+              BI	Burundi  
+              CV	Cabo Verde  
+              KH	Cambodia  
+              CM	Cameroon  
+              CA	Canada  
+              KY	Cayman Islands  
+              CF	Central African Republic  
+              TD	Chad  
+              CL	Chile  
+              CN	China  
+              CX	Christmas Island  
+              CC	Cocos (Keeling) Islands  
+              CO	Colombia  
+              KM	Comoros  
+              CG	Congo  
+              CD	Congo (DRC)  
+              CK	Cook Islands  
+              CR	Costa Rica  
+              CI	Côte d’Ivoire  
+              HR	Croatia  
+              CU	Cuba  
+              CW	Curaçao  
+              CY	Cyprus  
+              CZ	Czech Republic  
+              DK	Denmark  
+              DJ	Djibouti  
+              DM	Dominica  
+              DO	Dominican Republic  
+              EC	Ecuador  
+              EG	Egypt  
+              SV	El Salvador  
+              GQ	Equatorial Guinea  
+              ER	Eritrea  
+              EE	Estonia  
+              ET	Ethiopia  
+              FK	Falkland Islands  
+              FO	Faroe Islands  
+              FJ	Fiji  
+              FI	Finland  
+              FR	France  
+              GF	French Guiana  
+              PF	French Polynesia  
+              GA	Gabon  
+              GM	Gambia  
+              GE	Georgia  
+              DE	Germany  
+              GH	Ghana  
+              GI	Gibraltar  
+              GR	Greece  
+              GL	Greenland  
+              GD	Grenada  
+              GP	Guadeloupe  
+              GU	Guam  
+              GT	Guatemala  
+              GG	Guernsey  
+              GN	Guinea  
+              GW	Guinea-Bissau  
+              GY	Guyana  
+              HT	Haiti  
+              HN	Honduras  
+              HK	Hong Kong SAR  
+              HU	Hungary  
+              IS	Iceland  
+              IN	India  
+              ID	Indonesia  
+              IR	Iran  
+              IQ	Iraq  
+              IE	Ireland  
+              IM	Isle of Man  
+              IL	Israel  
+              IT	Italy  
+              JM	Jamaica  
+              JP	Japan  
+              JE	Jersey  
+              JO	Jordan  
+              KZ	Kazakhstan  
+              KE	Kenya  
+              KI	Kiribati  
+              KR	Korea  
+              XK	Kosovo  
+              KW	Kuwait  
+              KG	Kyrgyzstan  
+              LA	Laos  
+              LV	Latvia  
+              LB	Lebanon  
+              LS	Lesotho  
+              LR	Liberia  
+              LY	Libya  
+              LI	Liechtenstein  
+              LT	Lithuania  
+              LU	Luxembourg  
+              MO	Macao SAR  
+              MK	Macedonia, FYRO  
+              MG	Madagascar  
+              MW	Malawi  
+              MY	Malaysia  
+              MV	Maldives  
+              ML	Mali  
+              MT	Malta  
+              MH	Marshall Islands  
+              MQ	Martinique  
+              MR	Mauritania  
+              MU	Mauritius  
+              YT	Mayotte  
+              MX	Mexico  
+              FM	Micronesia  
+              MD	Moldova  
+              MC	Monaco  
+              MN	Mongolia  
+              ME	Montenegro  
+              MS	Montserrat  
+              MA	Morocco  
+              MZ	Mozambique  
+              MM	Myanmar  
+              NA	Namibia  
+              NR	Nauru  
+              NP	Nepal  
+              NL	Netherlands  
+              NC	New Caledonia  
+              NZ	New Zealand  
+              NI	Nicaragua  
+              NE	Niger  
+              NG	Nigeria  
+              NU	Niue  
+              NF	Norfolk Island  
+              KP	North Korea  
+              MP	Northern Mariana Islands  
+              NO	Norway  
+              OM	Oman  
+              PK	Pakistan  
+              PW	Palau  
+              PS	Palestinian Authority  
+              PA	Panama  
+              PG	Papua New Guinea  
+              PY	Paraguay  
+              PE	Peru  
+              PH	Philippines  
+              PN	Pitcairn Islands  
+              PL	Poland  
+              PT	Portugal  
+              PR	Puerto Rico  
+              QA	Qatar  
+              RE	Réunion  
+              RO	Romania  
+              RU	Russia  
+              RW	Rwanda  
+              BL	Saint Barthélemy  
+              KN	Saint Kitts and Nevis  
+              LC	Saint Lucia  
+              MF	Saint Martin  
+              PM	Saint Pierre and Miquelon  
+              VC	Saint Vincent and the Grenadines  
+              WS	Samoa  
+              SM	San Marino  
+              ST	São Tomé and Príncipe  
+              SA	Saudi Arabia  
+              SN	Senegal  
+              RS	Serbia  
+              SC	Seychelles  
+              SL	Sierra Leone  
+              SG	Singapore  
+              SX	Sint Maarten  
+              SK	Slovakia  
+              SI	Slovenia  
+              SB	Solomon Islands  
+              SO	Somalia  
+              ZA	South Africa  
+              SS	South Sudan  
+              ES	Spain  
+              LK	Sri Lanka  
+              SH	St Helena, Ascension, Tristan da Cunha  
+              SD	Sudan  
+              SR	Suriname  
+              SJ	Svalbard and Jan Mayen  
+              SZ	Swaziland  
+              SE	Sweden  
+              CH	Switzerland  
+              SY	Syria  
+              TW	Taiwan  
+              TJ	Tajikistan  
+              TZ	Tanzania  
+              TH	Thailand  
+              TL	Timor-Leste  
+              TG	Togo  
+              TK	Tokelau  
+              TO	Tonga  
+              TT	Trinidad and Tobago  
+              TN	Tunisia  
+              TR	Turkey  
+              TM	Turkmenistan  
+              TC	Turks and Caicos Islands  
+              TV	Tuvalu  
+              UM	U.S. Outlying Islands  
+              VI	U.S. Virgin Islands  
+              UG	Uganda  
+              UA	Ukraine  
+              AE	United Arab Emirates  
+              GB	United Kingdom  
+              US	United States  
+              UY	Uruguay  
+              UZ	Uzbekistan  
+              VU	Vanuatu  
+              VE	Venezuela  
+              VN	Vietnam  
+              WF	Wallis and Futuna  
+              YE	Yemen  
+              ZM	Zambia  
+              ZW	Zimbabwe
           required: false
           style: form
           explode: true
@@ -7778,6 +8290,11 @@ components:
         Country:
           type: string
           description: The user's country
+          nullable: true
+          deprecated: true
+        CountryCode:
+          type: string
+          description: The 2-character code for the user's country
           nullable: true
         Zip:
           type: string


### PR DESCRIPTION
Updated the Country field name to CountryCode

CountryCode as a Query Parameter
/CreateUser
/UpdateUser

CountryCode as a Field in the Response
/GetUser/{id}
/GetUserByEmail
/GetUserByExternalId/{Id}

NOTE: Deprecated the field "Country" for the above endpoints