### PR TITLE
Modified Skillable-lab-OpenAPI.yaml

### DIFF
--- a/Skillable-lab-OpenAPI.yaml
+++ b/Skillable-lab-OpenAPI.yaml
@@ -1656,7 +1656,7 @@ paths:
                 $ref: '#/components/schemas/LabSeriesResponse'
       deprecated: false
       tags:
-        - Lab Profile Management
+        - Lab Series Management
       x-stoplight:
         id: zn49rzfv0bjqw
     parameters: []


### PR DESCRIPTION
In line 1659, updated the tag for the Lab Series API to be "Lab Series Management" instead of "Lab Profile Management".